### PR TITLE
fix(README): images not being shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img src="src/assets/images/logo.png" alt="Vortex-logo" width="100"/> <br>
-  <img src="src/assets/images/vortex.png" alt="Vortex" width="400"/>
+  <img src="assets/images/logo.png" alt="Vortex-logo" width="100"/> <br>
+  <img src="assets/images/vortex.png" alt="Vortex" width="400"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

README images were not being shown due to now non-existent `src` folder in their path

## Checklist:

- [ ] This PR follows style guidelines (black, isort) of this project.
- [ ] This PR has been tested.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new.
- [x] This PR is **not** a code change (e.g. README, typos, ...)